### PR TITLE
Rework animations system

### DIFF
--- a/src/animations/mod.rs
+++ b/src/animations/mod.rs
@@ -3,68 +3,6 @@
 use std::time::Duration;
 use std::time::SystemTime;
 
-use Matrix;
-
-/// Describes a way to modify an element during an animation.
-pub trait Animation {
-    /// Takes an animation percentage between `0.0` and `1.0`. Returns the most-inner matrix to
-    /// multiply the element with.
-    fn animate(&self, percent: f32) -> Matrix;
-}
-
-/// Relative movement of the element from `initial_offset` to `[0.0, 0.0]`.
-pub struct Translation {
-    /// The initial position of the element at the start of the animation.
-    ///
-    /// A value of `1.0` corresponds to half of the size of the element.
-    pub initial_offset: [f32; 2],
-}
-
-impl Translation {
-    /// Builds a `Translation` object.
-    #[inline]
-    pub fn new(initial_offset: [f32; 2]) -> Translation {
-        Translation {
-            initial_offset: initial_offset,
-        }
-    }
-}
-
-impl Animation for Translation {
-    #[inline]
-    fn animate(&self, percent: f32) -> Matrix {
-        let x = (1.0 - percent) * self.initial_offset[0];
-        let y = (1.0 - percent) * self.initial_offset[1];
-        Matrix::translate(x, y)
-    }
-}
-
-/// Zooms the element from `initial_zoom` to `1.0`.
-pub struct Zoom {
-    /// The initial zoom of the element at the start of the animation.
-    ///
-    /// `1.0` is the normal size. `2.0` means twice bigger. `0.5` means twice smaller.
-    pub initial_zoom: f32,
-}
-
-impl Zoom {
-    /// Builds a `Zoom` object.
-    #[inline]
-    pub fn new(initial_zoom: f32) -> Zoom {
-        Zoom {
-            initial_zoom: initial_zoom,
-        }
-    }
-}
-
-impl Animation for Zoom {
-    #[inline]
-    fn animate(&self, percent: f32) -> Matrix {
-        let s = (1.0 - percent) * (self.initial_zoom - 1.0) + 1.0;
-        Matrix::scale(s)
-    }
-}
-
 /// Describes how an animation should be interpolated.
 pub trait Interpolation {
     /// Takes an instance representing the current point in time, an instant representing the

--- a/src/widgets/circular_progress_bar.rs
+++ b/src/widgets/circular_progress_bar.rs
@@ -67,7 +67,7 @@ pub fn stretch<D: ?Sized + Draw>(draw: &DrawContext<D>, empty: &D::ImageResource
             _ => unreachable!()
         };
 
-        draw.draw().draw_triangle(full, &(*draw.matrix() * local_matrix), [uv1, [0.5, 0.5], uv3]);
+        draw.draw().draw_triangle(full, &(draw.matrix() * local_matrix), [uv1, [0.5, 0.5], uv3]);
     }
 
     // Drawing the bottom-right image of each rectangle.
@@ -89,6 +89,6 @@ pub fn stretch<D: ?Sized + Draw>(draw: &DrawContext<D>, empty: &D::ImageResource
             _ => unreachable!()
         };
 
-        draw.draw().draw_triangle(full, &(*draw.matrix() * local_matrix), [uv1, [0.5, 0.5], uv3]);
+        draw.draw().draw_triangle(full, &(draw.matrix() * local_matrix), [uv1, [0.5, 0.5], uv3]);
     }
 }

--- a/src/widgets/image.rs
+++ b/src/widgets/image.rs
@@ -16,7 +16,7 @@ pub fn stretch<D: ?Sized + Draw>(draw: &DrawContext<D>, image_name: &D::ImageRes
         }
     }
 
-    draw.draw().draw_image(image_name, draw.matrix());
+    draw.draw().draw_image(image_name, &draw.matrix());
 }
 
 /// Increases the size of the image until it covers the context, and draws it.

--- a/src/widgets/image9.rs
+++ b/src/widgets/image9.rs
@@ -36,56 +36,56 @@ pub fn draw<D: ?Sized + Draw>(draw: &DrawContext<D>, left_border_percent: f32,
     // top left
     {
         let ctxt = draw.rescale(left_border_percent, top_border_percent, &Alignment::top_left());
-        draw.draw().draw_image_uv(image_name, ctxt.matrix(), [0.0, 1.0], [left_percent, 1.0],
+        draw.draw().draw_image_uv(image_name, &ctxt.matrix(), [0.0, 1.0], [left_percent, 1.0],
                                   [left_percent, 1.0 - top_percent], [0.0, 1.0 - top_percent]);
     }
 
     // top right
     {
         let ctxt = draw.rescale(right_border_percent, top_border_percent, &Alignment::top_right());
-        draw.draw().draw_image_uv(image_name, ctxt.matrix(), [1.0 - right_percent, 1.0], [1.0, 1.0],
+        draw.draw().draw_image_uv(image_name, &ctxt.matrix(), [1.0 - right_percent, 1.0], [1.0, 1.0],
                                   [1.0, 1.0 - top_percent], [1.0 - right_percent, 1.0 - top_percent]);
     }
 
     // bottom right
     {
         let ctxt = draw.rescale(right_border_percent, bottom_border_percent, &Alignment::bottom_right());
-        draw.draw().draw_image_uv(image_name, ctxt.matrix(), [1.0 - right_percent, bottom_percent],
+        draw.draw().draw_image_uv(image_name, &ctxt.matrix(), [1.0 - right_percent, bottom_percent],
                                   [1.0, bottom_percent], [1.0, 0.0], [1.0 - right_percent, 0.0]);
     }
 
     // bottom left
     {
         let ctxt = draw.rescale(left_border_percent, bottom_border_percent, &Alignment::bottom_left());
-        draw.draw().draw_image_uv(image_name, ctxt.matrix(), [0.0, bottom_percent],
+        draw.draw().draw_image_uv(image_name, &ctxt.matrix(), [0.0, bottom_percent],
                                   [left_percent, bottom_percent], [left_percent, 0.0], [0.0, 0.0]);
     }
 
     // top
     {
         let ctxt = draw.rescale(1.0 - left_border_percent - right_border_percent, top_border_percent, &Alignment::top());
-        draw.draw().draw_image_uv(image_name, ctxt.matrix(), [left_percent, 1.0], [1.0 - right_percent, 1.0],
+        draw.draw().draw_image_uv(image_name, &ctxt.matrix(), [left_percent, 1.0], [1.0 - right_percent, 1.0],
                                   [1.0 - right_percent, 1.0 - top_percent], [left_percent, 1.0 - top_percent]);
     }
 
     // left
     {
         let ctxt = draw.rescale(left_border_percent, 1.0 - top_border_percent - bottom_border_percent, &Alignment::left());
-        draw.draw().draw_image_uv(image_name, ctxt.matrix(), [0.0, 1.0 - top_percent], [left_percent, 1.0 - top_percent],
+        draw.draw().draw_image_uv(image_name, &ctxt.matrix(), [0.0, 1.0 - top_percent], [left_percent, 1.0 - top_percent],
                                   [left_percent, bottom_percent], [0.0, bottom_percent]);
     }
 
     // bottom
     {
         let ctxt = draw.rescale(1.0 - left_border_percent - right_border_percent, bottom_border_percent, &Alignment::bottom());
-        draw.draw().draw_image_uv(image_name, ctxt.matrix(), [left_percent, bottom_percent], [1.0 - right_percent, bottom_percent],
+        draw.draw().draw_image_uv(image_name, &ctxt.matrix(), [left_percent, bottom_percent], [1.0 - right_percent, bottom_percent],
                                   [1.0 - right_percent, 0.0], [left_percent, 0.0]);
     }
 
     // right
     {
         let ctxt = draw.rescale(right_border_percent, 1.0 - top_border_percent - bottom_border_percent, &Alignment::right());
-        draw.draw().draw_image_uv(image_name, ctxt.matrix(), [1.0 - right_percent, 1.0 - top_percent],
+        draw.draw().draw_image_uv(image_name, &ctxt.matrix(), [1.0 - right_percent, 1.0 - top_percent],
                                   [1.0, 1.0 - top_percent], [1.0, bottom_percent], [1.0 - right_percent, bottom_percent]);
     }
 
@@ -94,7 +94,7 @@ pub fn draw<D: ?Sized + Draw>(draw: &DrawContext<D>, left_border_percent: f32,
         let ctxt = draw.rescale(1.0 - left_border_percent - right_border_percent,
                                  1.0 - top_border_percent - bottom_border_percent,
                                  &Alignment::center());
-        draw.draw().draw_image_uv(image_name, ctxt.matrix(), [left_percent, 1.0 - top_percent],
+        draw.draw().draw_image_uv(image_name, &ctxt.matrix(), [left_percent, 1.0 - top_percent],
                                   [1.0 - right_percent, 1.0 - top_percent], [1.0 - right_percent, bottom_percent],
                                   [left_percent, bottom_percent]);
     }

--- a/src/widgets/image_button.rs
+++ b/src/widgets/image_button.rs
@@ -25,7 +25,7 @@ pub fn stretch<D: ?Sized + Draw>(draw: &DrawContext<D>, ui_state: &mut UiState,
         draw.set_cursor_hovered_widget();
 
         if Some(widget_id.clone()) == ui_state.active_widget {
-            draw.draw().draw_image(active_image, draw.matrix());
+            draw.draw().draw_image(active_image, &draw.matrix());
 
             if draw.cursor_was_released() {
                 ui_state.active_widget = None;
@@ -35,17 +35,17 @@ pub fn stretch<D: ?Sized + Draw>(draw: &DrawContext<D>, ui_state: &mut UiState,
             }
 
         } else if draw.cursor_was_pressed() {
-            draw.draw().draw_image(active_image, draw.matrix());
+            draw.draw().draw_image(active_image, &draw.matrix());
             ui_state.active_widget = Some(widget_id.clone());
             Interaction::None
 
         } else {
-            draw.draw().draw_image(hovered_image, draw.matrix());
+            draw.draw().draw_image(hovered_image, &draw.matrix());
             Interaction::None
         }
 
     } else {
-        draw.draw().draw_image(normal_image, draw.matrix());
+        draw.draw().draw_image(normal_image, &draw.matrix());
         Interaction::None
     }
 }

--- a/src/widgets/label.rs
+++ b/src/widgets/label.rs
@@ -25,7 +25,7 @@ pub fn flow<D: ?Sized + Draw>(draw: &DrawContext<D>, text_style: &D::TextStyle, 
             }
         }
 
-        draw.matrix().clone()
+        draw.matrix()
     })
 }
 
@@ -43,7 +43,7 @@ pub fn contain<D: ?Sized + Draw>(draw: &DrawContext<D>, text_style: &D::TextStyl
             }
         }
 
-        draw.matrix().clone()
+        draw.matrix()
     })
 }
 
@@ -61,7 +61,7 @@ pub fn cover<D: ?Sized + Draw>(draw: &DrawContext<D>, text_style: &D::TextStyle,
             }
         }
 
-        draw.matrix().clone()
+        draw.matrix()
     })
 }
 

--- a/src/widgets/progress_bar.rs
+++ b/src/widgets/progress_bar.rs
@@ -47,6 +47,6 @@ pub fn stretch<D: ?Sized + Draw>(draw: &DrawContext<D>, empty: &D::ImageResource
 
     // Drawing the full image.
     let draw = draw.horizontal_rescale(progress, progress_direction);
-    draw.draw().draw_image_uv(full, draw.matrix(), [0.0, 1.0], [progress, 1.0], [progress, 0.0],
+    draw.draw().draw_image_uv(full, &draw.matrix(), [0.0, 1.0], [progress, 1.0], [progress, 0.0],
                               [0.0, 0.0]);
 }


### PR DESCRIPTION
Current behavior: calling `animate()` requires passing an `Animation` and immediately applies the animation.

New behavior: calling `animate()` doesn't do anything, but all the following transformations on the context are applied as a certain percentage of the animation.
For example if you call `animate()` then `rescale()`, then the effective rescale will be multiplied by a certain percentage depending on the progress of the animation.
