### PR TITLE
Split Draw in two traits and make their resource parameters

### DIFF
--- a/src/draw.rs
+++ b/src/draw.rs
@@ -8,13 +8,7 @@
 use Matrix;
 
 /// Trait for a context that can handle drawing.
-pub trait Draw {
-    /// Type of a resource that represents an image.
-    type ImageResource: ?Sized;
-
-    /// Type of a resource that represents the style of a text: its font, color, etc.
-    type TextStyle: ?Sized;
-
+pub trait DrawImage<I: ?Sized> {
     /// Draws a single triangle that covers the top-left hand corner of the surface, pre-multiplied
     /// by the matrix.
     ///
@@ -28,7 +22,7 @@ pub trait Draw {
     /// top-left, bottom-left and top-right corners. `[0.0, 0.0]` is the bottom-left hand corner
     /// of the texture, and `[1.0, 1.0]` is the top-right hand corner. If you use OpenGL, you can
     /// pass through the values. If you use DirectX or Vulkan, you must do `y = 1.0 - y` somewhere.
-    fn draw_triangle(&mut self, texture: &Self::ImageResource, matrix: &Matrix,
+    fn draw_triangle(&mut self, texture: &I, matrix: &Matrix,
                      uv_coords: [[f32; 2]; 3]);
 
     /// Draws an image that covers the whole surface (from `-1.0` to `1.0` both horizontally and
@@ -37,7 +31,7 @@ pub trait Draw {
     /// This function should not try to preseve the aspect ratio of the image. This is handled by
     /// the caller.
     #[inline]
-    fn draw_image(&mut self, name: &Self::ImageResource, matrix: &Matrix) {
+    fn draw_image(&mut self, name: &I, matrix: &Matrix) {
         self.draw_image_uv(name, matrix, [0.0, 1.0], [1.0, 1.0], [1.0, 0.0], [0.0, 0.0])
     }
 
@@ -51,7 +45,7 @@ pub trait Draw {
     /// borders. Coordinates `[0.0, 0.0]` correspond to the bottom-left hand corner of the
     /// image, and `[1.0, 1.0]` correspond to the top-right hand corner.
     #[inline]
-    fn draw_image_uv(&mut self, name: &Self::ImageResource, matrix: &Matrix, top_left: [f32; 2],
+    fn draw_image_uv(&mut self, name: &I, matrix: &Matrix, top_left: [f32; 2],
                      top_right: [f32; 2], bottom_right: [f32; 2], bottom_left: [f32; 2])
     {
         self.draw_triangle(name, matrix, [top_left, bottom_left, top_right]);
@@ -61,18 +55,20 @@ pub trait Draw {
     }
 
     /// Given an image, this functions returns its width divided by its height.
-    fn get_image_width_per_height(&mut self, name: &Self::ImageResource) -> f32;
+    fn get_image_width_per_height(&mut self, name: &I) -> f32;
+}
 
+pub trait DrawText<T: ?Sized> {
     /// Does the same as `draw_image`, but draws a glyph of a text instead.
-    fn draw_glyph(&mut self, text_style: &Self::TextStyle, glyph: char, matrix: &Matrix);
+    fn draw_glyph(&mut self, text_style: &T, glyph: char, matrix: &Matrix);
 
     /// Returns the height of a line of text in EMs.
     ///
     /// This value is usually somewhere around `1.2`.
-    fn line_height(&self, text_style: &Self::TextStyle) -> f32;
+    fn line_height(&self, text_style: &T) -> f32;
 
     /// Returns information about a specific glyph.
-    fn glyph_infos(&self, text_style: &Self::TextStyle, glyph: char) -> GlyphInfos;
+    fn glyph_infos(&self, text_style: &T, glyph: char) -> GlyphInfos;
 
     /// Returns the kerning between two characters for the given font.
     ///
@@ -83,7 +79,7 @@ pub trait Draw {
     /// A positive value moves the second character further away from the first one, while a
     /// negative values moves the second character next to the first one. The value must be a
     /// multiple of 1 em. When in doubt, you can simply return `0.0`.
-    fn kerning(&self, text_style: &Self::TextStyle, first_char: char, second_char: char) -> f32;
+    fn kerning(&self, text_style: &T, first_char: char, second_char: char) -> f32;
 }
 
 /// Information about a single glyph.

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -16,7 +16,6 @@ use std::sync::atomic::Ordering;
 use std::time::Duration;
 use std::time::SystemTime;
 
-use Draw;
 use Matrix;
 use WidgetId;
 
@@ -44,9 +43,9 @@ impl SharedDrawContext {
     /// The cursor coordinates, if any, must be in OpenGL viewport coordinates. In other words,
     /// `[-1.0, -1.0]` corresponds to the bottom-left hand corner of the screen, and `[1.0, 1.0]`
     /// to the top-right hand corner.
-    pub fn draw<'b, D: ?Sized + Draw + 'b>(&self, width: f32, height: f32, draw: &'b mut D,
-                                           cursor: Option<[f32; 2]>, cursor_was_pressed: bool,
-                                           cursor_was_released: bool) -> DrawContext<'b, D>
+    pub fn draw<'b, D: ?Sized + 'b>(&self, width: f32, height: f32, draw: &'b mut D,
+                                    cursor: Option<[f32; 2]>, cursor_was_pressed: bool,
+                                    cursor_was_released: bool) -> DrawContext<'b, D>
     {
         DrawContext {
             matrix: Matrix::identity(),
@@ -85,7 +84,7 @@ struct Shared1 {
 }
 
 /// Contains everything required to draw a widget.
-pub struct DrawContext<'b, D: ?Sized + Draw + 'b> {
+pub struct DrawContext<'b, D: ?Sized + 'b> {
     shared1: Arc<Shared1>,
     shared2: Rc<Shared2<'b, D>>,
 
@@ -108,14 +107,14 @@ pub struct DrawContext<'b, D: ?Sized + Draw + 'b> {
     cursor_was_released: bool,
 }
 
-struct Shared2<'a, D: ?Sized + Draw + 'a> {
+struct Shared2<'a, D: ?Sized + 'a> {
     draw: RefCell<&'a mut D>,
 
     /// True if the cursor is over an element of the UI.
     cursor_hovered_widget: Cell<bool>,
 }
 
-impl<'b, D: ?Sized + Draw + 'b> DrawContext<'b, D> {
+impl<'b, D: ?Sized + 'b> DrawContext<'b, D> {
     /// UNSTABLE. Obtains the underlying `draw` object.
     #[inline]
     #[doc(hidden)]
@@ -565,7 +564,7 @@ impl<'b, D: ?Sized + Draw + 'b> DrawContext<'b, D> {
     }
 }
 
-impl<'a, 'b, D: ?Sized + Draw + 'b> Clone for DrawContext<'b, D> {
+impl<'a, 'b, D: ?Sized + 'b> Clone for DrawContext<'b, D> {
     fn clone(&self) -> DrawContext<'b, D> {
         DrawContext {
             matrix: self.matrix.clone(),
@@ -696,7 +695,7 @@ pub enum VerticalAlignment {
 }
 
 /// Iterator that splits a context in pieces and returns new contexts.
-pub struct SplitsIter<'a, 'b: 'a, I, D: ?Sized + Draw + 'b> {
+pub struct SplitsIter<'a, 'b: 'a, I, D: ?Sized + 'b> {
     parent: &'a DrawContext<'b, D>,
     weights: I,
     total_weight_inverse: f32,
@@ -704,7 +703,7 @@ pub struct SplitsIter<'a, 'b: 'a, I, D: ?Sized + Draw + 'b> {
     vertical: bool,
 }
 
-impl<'a, 'b: 'a, I, D: ?Sized + Draw + 'b> Iterator for SplitsIter<'a, 'b, I, D>
+impl<'a, 'b: 'a, I, D: ?Sized + 'b> Iterator for SplitsIter<'a, 'b, I, D>
     where I: Iterator<Item = f32>
 {
     type Item = DrawContext<'b, D>;
@@ -755,7 +754,7 @@ impl<'a, 'b: 'a, I, D: ?Sized + Draw + 'b> Iterator for SplitsIter<'a, 'b, I, D>
     }
 }
 
-impl<'a, 'b: 'a, I, D: ?Sized + Draw + 'b> ExactSizeIterator for SplitsIter<'a, 'b, I, D>
+impl<'a, 'b: 'a, I, D: ?Sized + 'b> ExactSizeIterator for SplitsIter<'a, 'b, I, D>
     where I: ExactSizeIterator<Item = f32>
 {
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,12 +38,11 @@
 //! ```rust
 //! // Object that will allow you to draw the UI.
 //! struct MyDrawer;
-//! impl immi::Draw for MyDrawer {
-//!     type ImageResource = str;
-//!     type TextStyle = str;
-//!
+//! impl immi::DrawImage<str> for MyDrawer {
 //!     fn draw_triangle(&mut self, _: &str, _: &immi::Matrix, _: [[f32; 2]; 3]) {}
 //!     fn get_image_width_per_height(&mut self, _: &str) -> f32 { 1.0 }
+//! }
+//! impl immi::DrawText<str> for MyDrawer {
 //!     fn draw_glyph(&mut self, _: &str, _: char, _: &immi::Matrix) { }
 //!     fn line_height(&self, _: &str) -> f32 { 1.2 }
 //!     fn kerning(&self, _: &str, _: char, _: char) -> f32 { 0.0 }
@@ -88,9 +87,9 @@
 //!
 //! Example:
 //!
-//! ```rust
+//! ```
 //! fn draw_ui<D>(ctxt: &immi::DrawContext<D>)
-//!     where D: immi::Draw<ImageResource = str>
+//!     where D: immi::DrawImage<str>
 //! {
 //!     // Assuming you immediately called `draw_ui` after creating the `DrawContext`, the `ctxt`
 //!     // object represents the whole viewport..
@@ -108,14 +107,15 @@
 //! }
 //!
 //! fn draw_bottom_bar<D>(ctxt: &immi::DrawContext<D>)
-//!     where D: immi::Draw<ImageResource = str>
+//!     where D: immi::DrawImage<str>
 //! {
 //!     // Draws an image on the bottom half of the screen
 //!     immi::widgets::image::draw(ctxt, "top_background", &immi::Alignment::center());
 //! }
 //! ```
 //!
-pub use draw::Draw;
+pub use draw::DrawImage;
+pub use draw::DrawText;
 pub use draw::GlyphInfos;
 pub use id::WidgetId;
 pub use layout::draw;

--- a/src/widgets/circular_progress_bar.rs
+++ b/src/widgets/circular_progress_bar.rs
@@ -17,7 +17,7 @@
 //! The direction is always clockwise. <-- TODO: allow choosing this
 //!
 use Alignment;
-use Draw;
+use DrawImage;
 use DrawContext;
 use Matrix;
 
@@ -31,8 +31,8 @@ use widgets::image;
 ///
 /// Panicks if `progress` is not between 0.0 and 1.0.
 #[inline]
-pub fn draw<D: ?Sized + Draw>(draw: &DrawContext<D>, empty: &D::ImageResource,
-                              full: &D::ImageResource, progress: f32, alignment: &Alignment)
+pub fn draw<D: ?Sized + DrawImage<I>, I: ?Sized>(draw: &DrawContext<D>, empty: &I,
+                                         full: &I, progress: f32, alignment: &Alignment)
 {
     let draw = draw.animation_stop();
     let ratio = draw.draw().get_image_width_per_height(empty);
@@ -44,8 +44,8 @@ pub fn draw<D: ?Sized + Draw>(draw: &DrawContext<D>, empty: &D::ImageResource,
 /// # Panic
 ///
 /// Panicks if `progress` is not between 0.0 and 1.0.
-pub fn stretch<D: ?Sized + Draw>(draw: &DrawContext<D>, empty: &D::ImageResource,
-                                 full: &D::ImageResource, progress: f32)
+pub fn stretch<D: ?Sized + DrawImage<I>, I: ?Sized>(draw: &DrawContext<D>, empty: &I,
+                                            full: &I, progress: f32)
 {
     assert!(progress >= 0.0);
     assert!(progress <= 1.0);

--- a/src/widgets/image.rs
+++ b/src/widgets/image.rs
@@ -10,12 +10,12 @@
 //! If you want to use an image as a button, see the other modules.
 
 use Alignment;
-use Draw;
+use DrawImage;
 use DrawContext;
 
 /// Decreases the size of the image if necessary until it fits in the context, then draws it.
-pub fn draw<D: ?Sized + Draw>(draw: &DrawContext<D>, image_name: &D::ImageResource,
-                              alignment: &Alignment)
+pub fn draw<D: ?Sized + DrawImage<I>, I: ?Sized>(draw: &DrawContext<D>, image_name: &I,
+                                                 alignment: &Alignment)
 {
     let draw = draw.animation_stop();
 
@@ -24,7 +24,7 @@ pub fn draw<D: ?Sized + Draw>(draw: &DrawContext<D>, image_name: &D::ImageResour
 }
 
 /// Stretches the image if necessary so that it corresponds to the context's area, then draws it.
-pub fn stretch<D: ?Sized + Draw>(draw: &DrawContext<D>, image_name: &D::ImageResource) {
+pub fn stretch<D: ?Sized + DrawImage<I>, I: ?Sized>(draw: &DrawContext<D>, image_name: &I) {
     if !draw.cursor_hovered_widget() {
         if draw.is_cursor_hovering() {
             draw.set_cursor_hovered_widget();
@@ -35,8 +35,8 @@ pub fn stretch<D: ?Sized + Draw>(draw: &DrawContext<D>, image_name: &D::ImageRes
 }
 
 /// Increases the size of the image until it covers the context, then draws it.
-pub fn cover<D: ?Sized + Draw>(draw: &DrawContext<D>, image_name: &D::ImageResource,
-                              alignment: &Alignment)
+pub fn cover<D: ?Sized + DrawImage<I>, I: ?Sized>(draw: &DrawContext<D>, image_name: &I,
+                                                  alignment: &Alignment)
 {
     let draw = draw.animation_stop();
     let ratio = draw.draw().get_image_width_per_height(image_name);

--- a/src/widgets/image9.rs
+++ b/src/widgets/image9.rs
@@ -20,7 +20,7 @@
 //! calculated by maintaining the correct aspect ratio.
 
 use Alignment;
-use Draw;
+use DrawImage;
 use DrawContext;
 
 /// Draws a 9-parts image.
@@ -29,9 +29,9 @@ use DrawContext;
 ///
 /// - Panics if `top_percent + bottom_percent > 1.0` or `left_percent + right_percent > 1.0`.
 ///
-pub fn draw<D: ?Sized + Draw>(draw: &DrawContext<D>, left_border_percent: f32,
-                              image_name: &D::ImageResource, top_percent: f32, right_percent: f32,
-                              bottom_percent: f32, left_percent: f32)
+pub fn draw<D: ?Sized + DrawImage<I>, I: ?Sized>(draw: &DrawContext<D>, left_border_percent: f32,
+                                                 image_name: &I, top_percent: f32, right_percent: f32,
+                                                 bottom_percent: f32, left_percent: f32)
 {
     assert!(top_percent + bottom_percent <= 1.0);
     assert!(left_percent + right_percent <= 1.0);

--- a/src/widgets/image9_button.rs
+++ b/src/widgets/image9_button.rs
@@ -7,7 +7,7 @@
 
 //! Same as `image9`, except that the image is clickable.
 
-use Draw;
+use DrawImage;
 use DrawContext;
 use UiState;
 
@@ -16,11 +16,11 @@ use widgets::image9;
 
 /// Same as `image9::draw`, except that the image is clickable. You can specify different images
 /// for when the button is non-hovered, hovered, or active. 
-pub fn draw<D: ?Sized + Draw>(draw: &DrawContext<D>, ui_state: &mut UiState,
-                              left_border_percent: f32, normal_image: &D::ImageResource,
-                              hovered_image: &D::ImageResource, active_image: &D::ImageResource,
-                              top_percent: f32, right_percent: f32, bottom_percent: f32,
-                              left_percent: f32) -> Interaction
+pub fn draw<D: ?Sized + DrawImage<I>, I: ?Sized>(draw: &DrawContext<D>, ui_state: &mut UiState,
+                                                 left_border_percent: f32, normal_image: &I,
+                                                 hovered_image: &I, active_image: &I,
+                                                 top_percent: f32, right_percent: f32, bottom_percent: f32,
+                                                 left_percent: f32) -> Interaction
 {
     let widget_id = draw.reserve_widget_id();
 

--- a/src/widgets/image_button.rs
+++ b/src/widgets/image_button.rs
@@ -14,17 +14,17 @@
 //! were clicked. 
 
 use Alignment;
-use Draw;
+use DrawImage;
 use DrawContext;
 use UiState;
 
 use widgets::Interaction;
 
 /// Same as `image::draw`, except that the image is clickable.
-pub fn draw<D: ?Sized + Draw>(draw: &DrawContext<D>, ui_state: &mut UiState,
-                              normal_image: &D::ImageResource, hovered_image: &D::ImageResource,
-                              active_image: &D::ImageResource, alignment: &Alignment)
-                              -> Interaction
+pub fn draw<D: ?Sized + DrawImage<I>, I: ?Sized>(draw: &DrawContext<D>, ui_state: &mut UiState,
+                                                 normal_image: &I, hovered_image: &I,
+                                                 active_image: &I, alignment: &Alignment)
+                                                 -> Interaction
 {
     let draw = draw.animation_stop();
     let ratio = draw.draw().get_image_width_per_height(normal_image);
@@ -33,9 +33,9 @@ pub fn draw<D: ?Sized + Draw>(draw: &DrawContext<D>, ui_state: &mut UiState,
 }
 
 /// Same as `image::stretch`, except that the image is clickable.
-pub fn stretch<D: ?Sized + Draw>(draw: &DrawContext<D>, ui_state: &mut UiState,
-                                 normal_image: &D::ImageResource, hovered_image: &D::ImageResource,
-                                 active_image: &D::ImageResource) -> Interaction
+pub fn stretch<D: ?Sized + DrawImage<I>, I: ?Sized>(draw: &DrawContext<D>, ui_state: &mut UiState,
+                                                    normal_image: &I, hovered_image: &I,
+                                                    active_image: &I) -> Interaction
 {
     let widget_id = draw.reserve_widget_id();
 

--- a/src/widgets/label.rs
+++ b/src/widgets/label.rs
@@ -12,7 +12,7 @@
 use std::mem;
 
 use Alignment;
-use Draw;
+use DrawText;
 use DrawContext;
 use HorizontalAlignment;
 use matrix::Matrix;
@@ -23,8 +23,8 @@ use matrix::Matrix;
 /// This is usually the function that you want in order to draw text. Even though the text
 /// can overflow its container if it is too long, it is usually visually better to have an
 /// overflow than to have multiple texts of different heights when they should be the same.
-pub fn flow<D: ?Sized + Draw>(draw: &DrawContext<D>, text_style: &D::TextStyle, text: &str,
-                              alignment: &HorizontalAlignment)
+pub fn flow<D: ?Sized + DrawText<T>, T: ?Sized>(draw: &DrawContext<D>, text_style: &T, text: &str,
+                                                alignment: &HorizontalAlignment)
 {
     let draw = draw.animation_stop();
     helper(&draw, text_style, text, |ratio| {
@@ -43,8 +43,8 @@ pub fn flow<D: ?Sized + Draw>(draw: &DrawContext<D>, text_style: &D::TextStyle, 
 
 /// Draws text. The text will be sized so that it is entirely contained within the context, and
 /// either its width or its height is equal to the width or the height of the context.
-pub fn contain<D: ?Sized + Draw>(draw: &DrawContext<D>, text_style: &D::TextStyle, text: &str,
-                                 alignment: &Alignment)
+pub fn contain<D: ?Sized + DrawText<T>, T: ?Sized>(draw: &DrawContext<D>, text_style: &T, text: &str,
+                                                   alignment: &Alignment)
 {
     let draw = draw.animation_stop();
     helper(&draw, text_style, text, |ratio| {
@@ -62,8 +62,8 @@ pub fn contain<D: ?Sized + Draw>(draw: &DrawContext<D>, text_style: &D::TextStyl
 
 /// Draws text. The text will be sized so that it entirely covers the context, and either its
 /// width or its height is equal to the width or the height of the context.
-pub fn cover<D: ?Sized + Draw>(draw: &DrawContext<D>, text_style: &D::TextStyle, text: &str,
-                               alignment: &Alignment)
+pub fn cover<D: ?Sized + DrawText<T>, T: ?Sized>(draw: &DrawContext<D>, text_style: &T, text: &str,
+                                                 alignment: &Alignment)
 {
     let draw = draw.animation_stop();
     helper(&draw, text_style, text, |ratio| {
@@ -79,8 +79,8 @@ pub fn cover<D: ?Sized + Draw>(draw: &DrawContext<D>, text_style: &D::TextStyle,
     })
 }
 
-fn helper<D: ?Sized + Draw, F>(draw: &DrawContext<D>, text_style: &D::TextStyle, text: &str,
-                               final_matrix: F)
+fn helper<D: ?Sized + DrawText<T>, T: ?Sized, F>(draw: &DrawContext<D>, text_style: &T, text: &str,
+                                                 final_matrix: F)
     where F: FnOnce(f32) -> Matrix
 {
     let mut glyphs: Vec<(char, Matrix)> = Vec::with_capacity(text.len());

--- a/src/widgets/progress_bar.rs
+++ b/src/widgets/progress_bar.rs
@@ -15,7 +15,7 @@
 //!
 
 use Alignment;
-use Draw;
+use DrawImage;
 use DrawContext;
 use HorizontalAlignment;
 
@@ -29,9 +29,10 @@ use widgets::image;
 ///
 /// Panicks if `progress` is not between 0.0 and 1.0.
 #[inline]
-pub fn draw<D: ?Sized + Draw>(draw: &DrawContext<D>, empty: &D::ImageResource,
-                              full: &D::ImageResource, progress: f32,
-                              progress_direction: &HorizontalAlignment, alignment: &Alignment)
+pub fn draw<D: ?Sized + DrawImage<I>, I: ?Sized>(draw: &DrawContext<D>, empty: &I,
+                                                 full: &I, progress: f32,
+                                                 progress_direction: &HorizontalAlignment,
+                                                 alignment: &Alignment)
 {
     let draw = draw.animation_stop();
     let ratio = draw.draw().get_image_width_per_height(empty);
@@ -44,9 +45,9 @@ pub fn draw<D: ?Sized + Draw>(draw: &DrawContext<D>, empty: &D::ImageResource,
 /// # Panic
 ///
 /// Panicks if `progress` is not between 0.0 and 1.0.
-pub fn stretch<D: ?Sized + Draw>(draw: &DrawContext<D>, empty: &D::ImageResource,
-                                 full: &D::ImageResource, progress: f32,
-                                 progress_direction: &HorizontalAlignment)
+pub fn stretch<D: ?Sized + DrawImage<I>, I: ?Sized>(draw: &DrawContext<D>, empty: &I,
+                                                    full: &I, progress: f32,
+                                                    progress_direction: &HorizontalAlignment)
 {
     assert!(progress >= 0.0);
     assert!(progress <= 1.0);


### PR DESCRIPTION
Makes it possible to have multiple different images and text styles implemented on the same drawer.